### PR TITLE
Update requests should use PUT instead of POST

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -91,6 +91,10 @@ module.exports = function (api_key, options) {
     _request('DELETE', path, data, callback);
   }
 
+  function put(path, data, callback) {
+    _request('PUT', path, data, callback);
+  }
+
   return {
     payments: {
       create: function(payment, cb) {
@@ -168,7 +172,7 @@ module.exports = function (api_key, options) {
         if (!(client_id && typeof client_id === 'string')) {
           return cb("client_id required");
         }
-        post("/v2/clients/" + client_id, data, cb);
+        put("/v2/clients/" + client_id, data, cb);
       },
       remove: function(client_id, cb) {
         if (!(client_id && typeof client_id === 'string')) {
@@ -194,7 +198,7 @@ module.exports = function (api_key, options) {
         if (!(offer_id && typeof offer_id === 'string')) {
           return cb("offer_id required");
         }
-        post("/v2/offers/" + offer_id, data, cb);
+        put("/v2/offers/" + offer_id, data, cb);
       },
       remove: function(offer_id, cb) {
         if (!(offer_id && typeof offer_id === 'string')) {
@@ -220,7 +224,7 @@ module.exports = function (api_key, options) {
         if (!(subscription_id && typeof subscription_id === 'string')) {
           return cb("subscription_id required");
         }
-        post("/v2/subscriptions/" + subscription_id, data, cb);
+        put("/v2/subscriptions/" + subscription_id, data, cb);
       },
       remove: function(subscription_id, cb) {
         if (!(subscription_id && typeof subscription_id === 'string')) {


### PR DESCRIPTION
The update requests (clients, offers, subscriptions) currently use POST which results in a 412 with "Api_Exception_InvalidParameter". 
