### PR TITLE
GET request requires data as the actual query string instead of request body

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -55,6 +55,11 @@ module.exports = function (api_key, options) {
       }
     });
 
+    if (method === 'GET' && Object.keys(data).length > 0) {
+      path += "?" + querystring.stringify(data);
+      data = {}
+    }
+
     var request_data = querystring.stringify(data);
 
     //console.log(method, "request for", path);


### PR DESCRIPTION
When providing data to a GET request (most likely to filter a list request) this data can not be sent as the request body, but instead has to be appended to the path as a query string. 

``` javascipt
var paymill = require("paymill-node")("privateKey")

paymill.transactions.list({client: "clientId"}, function (err, result) {
  // …
});
```

Currently, when issueing such a request, all transactions are returned due to the client parameter being ignored. When providing the client parameter via the query string I retrieve only the transactions belonging to that client.
