### PR TITLE
Adding a "remove" functionality for preauthorizations, fixing a typo in the details function, adding a few missing semicolons

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ called with an error code (if any) and then the response.
 * `paymill.preauthorizations` - (https://www.paymill.com/en-gb/documentation-3/reference/api-reference/#document-preauthorizations)
     * `.create(preauthorization)`
     * `.details(preauthorization_id)`
+    * `.remove(preauthorization_id)`
     * `.list(data)`
 * `paymill.transactions` - (https://www.paymill.com/en-gb/documentation-3/reference/api-reference/#document-transactions)
     * `.create(transaction)`

--- a/lib/main.js
+++ b/lib/main.js
@@ -61,7 +61,7 @@ module.exports = function (api_key, options) {
 
     if (method === 'GET' && Object.keys(data).length > 0) {
       path += "?" + querystring.stringify(data);
-      data = {}
+      data = {};
     }
 
     var request_data = querystring.stringify(data);
@@ -278,4 +278,4 @@ module.exports = function (api_key, options) {
       }
     }
   };
-}
+};

--- a/lib/main.js
+++ b/lib/main.js
@@ -141,7 +141,6 @@ module.exports = function (api_key, options) {
         }
         del("/v2/preauthorizations/" + preauthorization_id, {}, cb);
       },
-      }
       list: function(data, cb) {
         get("/v2/preauthorizations", data, cb);
       }

--- a/lib/main.js
+++ b/lib/main.js
@@ -135,6 +135,13 @@ module.exports = function (api_key, options) {
         }
         get("/v2/preauthorizations/" + preauthorization_id, {}, cb);
       },
+      remove: function(preauthorization_id, cb) {
+        if (!(preauthorizations_id && typeof preauthorization_id === 'string')) {
+          return cb("preauthorization_id required");
+        }
+        del("/v2/preauthorizations/" + preauthorization_id, {}, cb);
+      },
+      }
       list: function(data, cb) {
         get("/v2/preauthorizations", data, cb);
       }

--- a/lib/main.js
+++ b/lib/main.js
@@ -130,13 +130,13 @@ module.exports = function (api_key, options) {
         post("/v2/preauthorizations", preauthorization, cb);
       },
       details: function(preauthorization_id, cb) {
-        if (!(preauthorizations_id && typeof preauthorization_id === 'string')) {
+        if (!(preauthorization_id && typeof preauthorization_id === 'string')) {
           return cb("preauthorization_id required");
         }
         get("/v2/preauthorizations/" + preauthorization_id, {}, cb);
       },
       remove: function(preauthorization_id, cb) {
-        if (!(preauthorizations_id && typeof preauthorization_id === 'string')) {
+        if (!(preauthorization_id && typeof preauthorization_id === 'string')) {
           return cb("preauthorization_id required");
         }
         del("/v2/preauthorizations/" + preauthorization_id, {}, cb);


### PR DESCRIPTION
The main goal of this pull request is to add the remove functionality for preauthorizations, to enable users to cancel a preauthorization.
